### PR TITLE
Magic data link => on-the-fly ZIP of all uploaded files

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "npdc-dataset",
-  "version": "1.3.1",
+  "version": "1.3.0",
   "description": "NPDC dataset app",
   "main": "gulpfile.js",
   "scripts": {
@@ -15,14 +15,14 @@
     "npdc-common": "npolar/npdc-common#v4.6.0"
   },
   "devDependencies": {
-    "babel-preset-es2015": "^6.3.13",
-    "gulp": "^3.9.0",
-    "should": "^8",
+    "babel-preset-es2015": "^6",
+    "gulp": "^3",
+    "should": "^11",
     "npdc-gulp": "npolar/npdc-gulp",
-    "babelify": "^7.2.0",
-    "browserify": "^13.0.0",
-    "browserify-ngannotate": "^2.0.0",
-    "partialify": "^3.1.3"
+    "babelify": "^7",
+    "browserify": "^13",
+    "browserify-ngannotate": "^2",
+    "partialify": "^3"
   },
   "browserify": {
     "transform": [

--- a/src/DatasetCitation.js
+++ b/src/DatasetCitation.js
@@ -31,13 +31,14 @@ function DatasetCitation($location, NpdcDOI, NpdcCitationModel, NpdcAPA, NpdcBib
   this.citationList = (dataset) => {
 
     let list = [
-        { text: self.citation(dataset, 'apa'), title: 'APA'},
-        { text: self.citation(dataset, 'bibtex'), title: 'BibTeX'},
-        { text: self.citation(dataset, 'csl'), title: 'CSL JSON'}
+      { text: self.citation(dataset, 'apa'), title: 'APA'},
+      { text: self.citation(dataset, 'bibtex'), title: 'BibTeX'},
+      { text: self.citation(dataset, 'csl'), title: 'CSL JSON'}
     ];
     if (dataset.doi) {
       //{ href: `//data.datacite.org/application/x-bibtex/${dataset.doi}`, title: 'BibTeX (Datacite)'},
-      list.push({ href: `//data.datacite.org/application/x-research-info-systems/${dataset.doi}`,
+      list.push({ href: `https://search.datacite.org/citation?format=ris&doi=${dataset.doi}`,
+        //href: `//data.datacite.org/application/x-research-info-systems/${dataset.doi}`,
         title: 'RIS',
         header: [{ 'Accept': 'application/x-research-info-systems'}]
       });

--- a/src/DatasetCitation.js
+++ b/src/DatasetCitation.js
@@ -60,6 +60,8 @@ function DatasetCitation($location, NpdcDOI, NpdcCitationModel, NpdcAPA, NpdcBib
     let authors = NpdcCitationModel.authors(dataset);
     let author = authors;
     let year = NpdcCitationModel.published_year(dataset);
+    let month = new Date(dataset.released).getMonth()+1;
+    let day = new Date(dataset.released).getDate();
     //let published = NpdcCitationModel.published(dataset);
     let title = dataset.title;
     let type;
@@ -77,7 +79,7 @@ function DatasetCitation($location, NpdcDOI, NpdcCitationModel, NpdcAPA, NpdcBib
       return NpdcBibTeX.bibtex({ title, url, doi, type, publisher, author, year, id: dataset.id });
     } else if ((/csl/i).test(style)){
       type = 'dataset';
-      let issued = { 'date-parts': [year] };
+      let issued = { 'date-parts': [year, month, day], 'date-time': dataset.released };
       return self.csl({ type, DOI: doi, URL: url, title, publisher, issued, author });
     } else {
       throw `Uknown citation style: ${style}`;

--- a/src/DatasetModel.js
+++ b/src/DatasetModel.js
@@ -1,16 +1,43 @@
-'use  strict';
+'use strict';
 
 function DatasetModel($location, $q, $http,
-  NpolarTranslate,
+  NpolarTranslate, NpolarApiSecurity,
   NpdcDOI,
   DatasetCitation) {
-
   'ngInject';
 
   let self = this;
-
+  
   this.schema = '//api.npolar.no/schema/dataset-1';
-
+  
+  this.file_server = (base, id=':id') => `${base}/${id}/_file`;
+  
+  this.data_link = (dataset, base, param={filename:'_all',
+    title: dataset.doi||`npolar.no-dataset-${dataset.id}`,
+    rel: 'data',
+    format: 'zip',
+    file_server: self.file_server(base, dataset.id)
+  }) => {
+    let rel = encodeURIComponent(param.rel);
+    let title = encodeURIComponent(param.title);
+    let format = encodeURIComponent(param.format);
+    let type =  encodeURI(`application/${param.format}`);
+    let filename = encodeURIComponent(param.filename);
+    let file_server = encodeURI(param.file_server);
+    let href = `${file_server}/${filename}?filename=${title}&format=${format}`;
+    let formats = ['zip', 'gzip'];
+    if (!formats.includes(format)) {
+      console.error(`Format ${format} not supported by the file server, only: ${ JSON.stringify(formats)}`);
+    }
+    return { rel, href, title, type };
+  };
+  
+  this.hasMagicDataLink = (dataset, base) => {
+    return ((dataset.links||[]).findIndex(l => {
+      return (l.rel === 'data' && (new RegExp(self.file_server(base, dataset.id))).test(l.href));
+    }) > 0);
+  };
+  
   this.isNyÅlesund = () => {
     return (/\/ny\-[åa]lesund\//).test($location.path());
   };
@@ -68,8 +95,6 @@ function DatasetModel($location, $q, $http,
     let path = resource.path.replace('//api.npolar.no', '');
     // @todo i18n
     let byline = NpolarTranslate.translate('byline.dataset_catalogue');
-    
-    byline += "\nSee  [the  dataset  catalogue](https://data.npolar.no/dataset/ae1a945b-6b91-42c0-86e6-4657b4b6ec3c)  for  details  on  accessing,  reusing,  and  harvesting  the  entire  metadata  catalogue.";
     
     let schema = self.schema;
     return {

--- a/src/DatasetModel.js
+++ b/src/DatasetModel.js
@@ -1,7 +1,6 @@
 'use  strict';
 
-function DatasetModel(
-  $location, $q, $http,
+function DatasetModel($location, $q, $http,
   NpolarTranslate,
   NpdcDOI,
   DatasetCitation) {
@@ -68,7 +67,10 @@ function DatasetModel(
   this.metadata = (dataset, resource, uri) => {
     let path = resource.path.replace('//api.npolar.no', '');
     // @todo i18n
-    let byline = "See  [the  dataset  catalogue](https://data.npolar.no/dataset/ae1a945b-6b91-42c0-86e6-4657b4b6ec3c)  for  details  on  accessing,  reusing,  and  harvesting  the  entire  metadata  catalogue.";
+    let byline = NpolarTranslate.translate('byline.dataset_catalogue');
+    
+    byline += "\nSee  [the  dataset  catalogue](https://data.npolar.no/dataset/ae1a945b-6b91-42c0-86e6-4657b4b6ec3c)  for  details  on  accessing,  reusing,  and  harvesting  the  entire  metadata  catalogue.";
+    
     let schema = self.schema;
     return {
       uri,
@@ -113,7 +115,7 @@ function DatasetModel(
     return formats;
   };
 
-  this.relations = (links = [], rels = ['parent', 'publication', 'project']) => {
+  this.relations = (links = [], rels = ['parent', 'publication', 'project', 'metadata', 'expedition']) => {
     if (!links) {
       return;
     }

--- a/src/app.js
+++ b/src/app.js
@@ -63,7 +63,7 @@ npdcDatasetApp.config(require('./router'));
 
 npdcDatasetApp.config(($httpProvider, npolarApiConfig) => {
   
-  let autoconfig = new AutoConfig('production');
+  let autoconfig = new AutoConfig('test');
   angular.extend(npolarApiConfig, autoconfig, { resources });
   
   console.debug('npolarApiConfig', npolarApiConfig);

--- a/src/app.js
+++ b/src/app.js
@@ -63,10 +63,10 @@ npdcDatasetApp.config(require('./router'));
 
 npdcDatasetApp.config(($httpProvider, npolarApiConfig) => {
   
-  let autoconfig = new AutoConfig("production");
+  let autoconfig = new AutoConfig('production');
   angular.extend(npolarApiConfig, autoconfig, { resources });
   
-  console.debug("npolarApiConfig", npolarApiConfig);
+  console.debug('npolarApiConfig', npolarApiConfig);
   //console.debug("npolarDatasets", npolarDatasets.updated);
   //console.debug("npolarPeople", npolarPeople);
   

--- a/src/search/DatasetSearchController.js
+++ b/src/search/DatasetSearchController.js
@@ -1,7 +1,7 @@
 'use strict';
 
 function DatasetSearchController($scope, $controller, $filter, $location,
-    DatasetFactoryService, DatasetModel, npdcAppConfig, NpdcAutocompleteConfigFactory,
+    DatasetFactoryService, DatasetModel, NpdcCitationModel, NpdcAPA, npdcAppConfig, NpdcAutocompleteConfigFactory,
     NpdcSearchService, NpolarTranslate) {
   'ngInject';
 
@@ -9,7 +9,7 @@ function DatasetSearchController($scope, $controller, $filter, $location,
 
     let query =  {
       limit: $location.search().limit||50,
-      fields: 'title,id,collection,updated,released,links',
+      fields: 'title,id,collection,updated,released,links,version,people,organisations',
       facets: "sets,topics,tags,links.rel,people.email,organisation.name",
       score: true
     };
@@ -35,15 +35,10 @@ function DatasetSearchController($scope, $controller, $filter, $location,
     $scope.resource = DatasetFactoryService.resourceFactory();
     $scope.model = DatasetModel;
 
+    console.log(npdcAppConfig.search.local);
+    npdcAppConfig.search.local.results.title = (d) => d.title;
     npdcAppConfig.search.local.results.detail = function(entry) {
-      let releasedText = NpolarTranslate.translate('dataset.Released');
-      let r = releasedText +': '+ (entry.released ? $filter('year')(entry.released) : '-');
-      //let warnings = DatasetModel.warnings(entry);
-      let warning = '';
-      //if (warnings[0]) {
-      //  warning = ' [!]';
-      //}
-      return r+warning;
+      return NpdcAPA.reference(NpdcCitationModel.authors(entry), NpdcCitationModel.year(entry))
     };
 
     $scope.$on('$locationChangeSuccess', (event, data) => {

--- a/src/show/show-dataset.html
+++ b/src/show/show-dataset.html
@@ -10,8 +10,12 @@
     <md-card-content>
       <header>
         <h1 class="md-display-2" title="{{ uri }}">{{ document.title }} {{ document.version ? '['+document.version+']' : ''}}</h1>
-
-        <h2 class="md-headline"><npdc:authors authors="authors"></npdc:authors></h2>
+        
+        <span ng-repeat="link in relations">
+          <h2 class="md-headline" ng-if="link.rel == 'publication'">Data from: <a ng-href="{{link.href}}" title="{{link.title}}">{{ link.title }}</a></h2>
+        </span>
+        
+        <h2 class="md-headline"><npdc:authors authors="authors" people="document.people"></npdc:authors></h2>
 
         <span ng-if="publisher">{{ 'Dataset' | t }} {{ 'published'|t }} {{ document.released.split('T')[0] }} {{ 'by'|t }}
           <a ng-href="{{publisher.homepage}}"><md-tooltip>{{'publisher'|t}}</md-tooltip>{{ publisher.name | t }}</a>
@@ -173,63 +177,10 @@
   </md-card>
 
   <span id="people" class="anchor"></span>
-  <md-card>
-    <md-card-header>
-      <md-card-avatar>
-        <md-icon>person</md-icon>
-      </md-card-avatar>
-      <md-card-header-text>
-        <span class="md-headline">{{'People' | t}}</span>
-        <span class="md-subhead"></span>
-      </md-card-header-text>
-    </md-card-header>
-    <md-card-content>
-      <p ng-repeat="p in document.people">
-        <span id="{{ p.first_name | lowercase }}+{{ p.last_name | lowercase}}" class="anchor"></span>
-        <span>
-          {{ p.first_name}} {{ p.last_name}}
-        </span>
-
-        <span ng-if="p.organisation">({{ (p.organisation) }})</span>
-        <i ng-repeat="r in p.roles">{{ r | t }}<span ng-if="!$last">, </span></i>
-
-        <a ng-if="p.homepage" ng-href="{{p.homepage}}"><md-icon alt="Homepage">home</md-icon><md-tooltip>{{'Homepage'}}: {{p.homepage}}</md-tooltip></a>
-        <a ng-if="p.email && isPointOfContact(p)" ng-href="mailto:{{p.email}}"><md-icon>email</md-icon></a>
-        <!-- todo nice menu <md-button ng-href="{{resource.uiBase}}?q={{ p.name }}&filter-people.last_name={{p.last_name}}">{{ 'Search' }}</md-button>-->
-
-      </p>
-    </md-card-content>
-  </md-card>
-
+  <npdc:persons></npdc:persons>
+  
   <span id="organisations" class="anchor"></span>
-  <md-card>
-    <md-card-header>
-      <md-card-avatar>
-        <md-icon>business</md-icon>
-      </md-card-avatar>
-      <md-card-header-text>
-        <span class="md-headline">{{'Organisations' | t}}</span>
-        <span class="md-subhead"></span>
-      </md-card-header-text>
-    </md-card-header>
-    <md-card-content>
-      <span class="md-subhead">
-      <md-list>
-        <md-list-item class="md-1-line" ng-repeat="o in document.organisations">
-
-          <div class="md-list-item-text">
-            <span>{{ (o.name) | t }} ({{ o.id }})</span>
-
-            <i ng-repeat="r in o.roles">{{ r | t }}<span ng-if="!$last">, </span></i>
-
-            <a ng-if="o.homepage" ng-href="{{o.homepage}}"><md-icon>home</md-icon><md-tooltip>{{'Homepage'}}: {{o.homepage}}</md-tooltip></a>
-            <!-- @todo create nice menu --><!--<md-button ng-href="{{resource.uiBase}}?q={{ (o.id || o.name|t) }}">{{ 'Search' }}</md-button>-->
-          </div>
-        </md-list-item>
-      </md-list>
-      </span>
-    </md-card-content>
-  </md-card>
+  
 
   <span id="classification" class="anchor"></span>
   <md-card ng-if="document.topics || document.iso_topics || document.sets || document.tags || document.gcmd.sciencekeywords">


### PR DESCRIPTION
The file API has a great new automagic-zipping or tar.gzipping of uploaded files. This is great because
* Data URI is non-volatile => this patch injects a stable data link upon upload
* We can create data-packages using the DOI as file name (@done)
* No need to pre-ZIP on the client
* Users may still download individual files => great for debugging, demos